### PR TITLE
Live API

### DIFF
--- a/lib/piwik/live.rb
+++ b/lib/piwik/live.rb
@@ -6,5 +6,11 @@ module Piwik
       getVisitorProfile
       getMostRecentVisitorId
     }
+
+    scoped_methods do
+      def last_visits params = {}
+        getLastVisitsDetails(defaults.merge(params))
+      end
+    end
   end
 end

--- a/lib/piwik/live.rb
+++ b/lib/piwik/live.rb
@@ -3,6 +3,8 @@ module Piwik
     available_methods %W{
       getCounters
       getLastVisitsDetails
+      getVisitorProfile
+      getMostRecentVisitorId
     }
   end
 end


### PR DESCRIPTION
Adds support for the Matomo [Live Reporting API](https://developer.matomo.org/api-reference/reporting-api#Live).
Used by https://github.com/Monsido/monsido_app/pull/4696