### PR TITLE
Remove in gemspec requirement activesupport < 6 

### DIFF
--- a/autometal-piwik.gemspec
+++ b/autometal-piwik.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('xml-simple')
   s.add_dependency('rest-client')
-  s.add_dependency('activesupport', '>= 3.0', '< 6.0')
+  s.add_dependency('activesupport', '>= 3.0', '< 7.0')
   s.add_development_dependency('rspec', '< 3.0')
 end


### PR DESCRIPTION
To be able to integrate the gem with rails 6.
This was done in the same way upstream, i.e. without any code changes:
https://github.com/matomo-org/piwik-ruby-api/pull/23