### PR TITLE
Matomo 4 has renamed getBrowserFamilies to getBrowserEngines

### DIFF
--- a/lib/piwik/devices_detection.rb
+++ b/lib/piwik/devices_detection.rb
@@ -8,6 +8,7 @@ module Piwik
       getOsVersions
       getBrowserVersions
       getBrowserFamilies
+      getBrowserEngines
     }
 
     scoped_methods do
@@ -36,7 +37,11 @@ module Piwik
       end
 
       def browser_families params = {}
-        getBrowserFamilies(defaults.merge(params))
+        if Gem::Version.new(API.getPiwikVersion(defaults.merge(params)).value) >= Gem::Version.new("4.0.0")
+          getBrowserEngines(defaults.merge(params))
+        else
+          getBrowserFamilies(defaults.merge(params))
+        end
       end
     end
   end

--- a/lib/piwik/version.rb
+++ b/lib/piwik/version.rb
@@ -1,3 +1,3 @@
 module Piwik
-  VERSION = "1.0.13"
+  VERSION = "1.0.14"
 end


### PR DESCRIPTION
Makes the code compatible with Matomo 3 and 4 at the same time