### PR TITLE
UPDATES: activesupport in gemspec and bump version

### DIFF
--- a/autometal-piwik.gemspec
+++ b/autometal-piwik.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('xml-simple', '>= 1.1.9')
   s.add_dependency('excon')
-  s.add_dependency('activesupport', '>= 7.2.3.1', '< 8.0')
+  s.add_dependency('activesupport', '>= 7.2.3.1', '< 9.0')
   s.add_development_dependency('rspec', '< 3.0')
   s.add_development_dependency('rspec-its', '< 3.0')
 end

--- a/autometal-piwik.gemspec
+++ b/autometal-piwik.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('xml-simple', '>= 1.1.9')
   s.add_dependency('excon')
-  s.add_dependency('activesupport', '>= 7.2.3.1', '< 9.0')
+  s.add_dependency('activesupport', '>= 8.0.5.1', '< 9.0')
   s.add_development_dependency('rspec', '< 3.0')
   s.add_development_dependency('rspec-its', '< 3.0')
 end

--- a/lib/piwik/version.rb
+++ b/lib/piwik/version.rb
@@ -1,3 +1,3 @@
 module Piwik
-  VERSION = "1.0.15"
+  VERSION = "1.0.16"
 end


### PR DESCRIPTION
ActiveSupport needs to be able to go to v8 in order for us to upgrade to rails 8 in monsido_app

Before:

`s.add_dependency('activesupport', '>= 7.2.3.1, '< 8.0')`

Now:

s.add_dependency('activesupport', '>= 8.0.5.1', '< 9.0')

Version therefore bumped to 1.0.16 in this branch as well.